### PR TITLE
Basic Keycloak deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/mesh-infra/keycloak/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/keycloak/app.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: keycloak
+- op: replace
+  path: /spec/source/path
+  value: deployment/mesh-infra/keycloak

--- a/deployment/mesh-infra/argocd/projects/mesh-infra/keycloak/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/keycloak/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/argocd/projects/mesh-infra/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - argocd
 - grafana
 - jaeger
+- keycloak
 - kiali
 - prometheus
 - routing

--- a/deployment/mesh-infra/argocd/projects/mesh-infra/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - kiali
 - prometheus
 - routing
+- storage

--- a/deployment/mesh-infra/argocd/projects/mesh-infra/storage/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/storage/app.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/name
+  value: storage
+- op: replace
+  path: /spec/source/path
+  value: deployment/mesh-infra/storage

--- a/deployment/mesh-infra/argocd/projects/mesh-infra/storage/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/mesh-infra/storage/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/keycloak/base.yaml
+++ b/deployment/mesh-infra/keycloak/base.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: keycloak
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  namespace: default
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+      - name: keycloak
+        image: quay.io/keycloak/keycloak:16.1.0
+        env:
+        - name: KEYCLOAK_USER
+          value: "admin"
+        - name: KEYCLOAK_PASSWORD
+          value: "admin"
+        - name: PROXY_ADDRESS_FORWARDING
+          value: "true"
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: https
+          containerPort: 8443
+        readinessProbe:
+          httpGet:
+            path: /auth/realms/master
+            port: 8080

--- a/deployment/mesh-infra/keycloak/base.yaml
+++ b/deployment/mesh-infra/keycloak/base.yaml
@@ -35,10 +35,6 @@ spec:
       - name: keycloak
         image: quay.io/keycloak/keycloak:16.1.0
         env:
-        - name: KEYCLOAK_USER
-          value: "admin"
-        - name: KEYCLOAK_PASSWORD
-          value: "admin"
         - name: PROXY_ADDRESS_FORWARDING
           value: "true"
         ports:
@@ -50,3 +46,10 @@ spec:
           httpGet:
             path: /auth/realms/master
             port: 8080
+        volumeMounts:
+        - name: h2-volume
+          mountPath: /opt/jboss/keycloak/standalone/data
+      volumes:
+      - name: h2-volume
+        persistentVolumeClaim:
+          claimName: keycloak-pvc

--- a/deployment/mesh-infra/keycloak/kustomization.yaml
+++ b/deployment/mesh-infra/keycloak/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml

--- a/deployment/mesh-infra/kustomization.yaml
+++ b/deployment/mesh-infra/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - argocd/
 - grafana/
 - jaeger/
+- keycloak/
 - kiali/
 - prometheus/
 - routing/

--- a/deployment/mesh-infra/kustomization.yaml
+++ b/deployment/mesh-infra/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - kiali/
 - prometheus/
 - routing/
+- storage/

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -49,3 +49,11 @@ spec:
         host: quantumleap.default.svc.cluster.local
         port:
           number: 8668
+  - match:
+    - uri:
+        prefix: /auth
+    route:
+    - destination:
+        host: keycloak.default.svc.cluster.local
+        port:
+          number: 8080

--- a/deployment/mesh-infra/storage/keycloak.yaml
+++ b/deployment/mesh-infra/storage/keycloak.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: microk8s-hostpath
+  resources:
+    requests:
+      storage: 1Gi

--- a/deployment/mesh-infra/storage/kustomization.yaml
+++ b/deployment/mesh-infra/storage/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- keycloak.yaml


### PR DESCRIPTION
This PR implements basic Keycloak deployment to the KITT4SME live cluster as requested by #9.

We implemented the following features:

- Basic manifests to run Keycloak in a K8s cluster. Keycloak runs in standalone HA mode so it's possible to scale it going forward.
- Keycloak persistence. Keycloak is configured with H2 as a backing database. The DB instance is embedded in Keycloak so if we want to scale Keycloak we've got to replace H2 with an external DB---e.g. Postgres. But that's an easy thing to do, so for now we're going to keep it simple.
- Physical storage. H2 writes its DB files to `/opt/jboss/keycloak/standalone/data` so we mount this dir on a K8s volume backed by 1GB physical storage.
- Keycloak master realm admin. We don't provide one by default so there's no master admin passwords lying around anywhere. Istead the server is configured to let a mesh admin to enter the initial master admin credentials in a secure way, through a Web form whose content gets saved to the Keycloak DB.
- Routing. Clients from outside the mesh can get to Keycloak at `mesh-domain:80/auth`. External traffic gets forwarded to the Keycloak Envoy sidecar which then in turn forwards to the actual Keycloak service.
- IaC management. The Keycloak manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too. Ditto for the storage manifest.