### PR TITLE
SUPSI OPC UA agent

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 - cratedb
 - grafana
 - mongodb
+- opcua-agent-supsi
 - orion
 - quantumleap

--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/opcua-agent-supsi/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/opcua-agent-supsi/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: opcua-agent-supsi
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-infra-services/opcua-agent-supsi
+- op: replace
+  path: /spec/project
+  value: plat-infra-services

--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/opcua-agent-supsi/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/opcua-agent-supsi/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/plat-infra-services/kustomization.yaml
+++ b/deployment/plat-infra-services/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - cratedb/
 - grafana/
 - mongodb/
+- opcua-agent-supsi/
 - orion/
 - quantumleap/

--- a/deployment/plat-infra-services/opcua-agent-supsi/base.yaml
+++ b/deployment/plat-infra-services/opcua-agent-supsi/base.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: opcua-agent-supsi
+  labels:
+    app: opcua-agent-supsi
+spec:
+  selector:
+    app: opcua-agent-supsi
+  ports:
+  - name: iota-north
+    port: 4001
+    targetPort: 4001
+    protocol: TCP
+  - name: rest-svc
+    port: 4081
+    targetPort: 8080
+    protocol: TCP
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opcua-agent-supsi
+  labels:
+    app: opcua-agent-supsi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opcua-agent-supsi
+  template:
+    metadata:
+      labels:
+        app: opcua-agent-supsi
+    spec:
+      containers:
+      - name: opcua-agent-supsi
+        image: "iotagent4fiware/iotagent-opcua:1.4.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: iota-north
+          containerPort: 4001
+        - name: rest-svc
+          containerPort: 8080
+        volumeMounts:
+          - name: config
+            mountPath: /usr/src/app/conf
+            # stop clients from changing the config we mount.
+            # NOTE the :8080/json endpoint lets you upload a new JSON
+            # file to override /usr/src/app/conf/config.json.
+            readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: opcua-agent-supsi-config

--- a/deployment/plat-infra-services/opcua-agent-supsi/base.yaml
+++ b/deployment/plat-infra-services/opcua-agent-supsi/base.yaml
@@ -26,7 +26,7 @@ metadata:
   labels:
     app: opcua-agent-supsi
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: opcua-agent-supsi

--- a/deployment/plat-infra-services/opcua-agent-supsi/config.json
+++ b/deployment/plat-infra-services/opcua-agent-supsi/config.json
@@ -1,0 +1,38 @@
+{
+	"logLevel": "DEBUG",
+	"multiCore": false,
+	"relaxTemplateValidation": true,
+	"contextBroker": {
+		"host": "orion",
+		"port": 1026,
+		"ngsiVersion": "v2",
+		"jsonLdContext": "",
+		"service": "supsi",
+		"subservice": "/"
+	},
+	"server": {
+		"port": 4001,
+		"baseRoot": "/"
+	},
+	"deviceRegistry": {
+		"type": "memory"
+	},
+	"mongodb": {
+		"host": "nowhere",
+		"port": "27017",
+		"db": "opcua_agent_supsi",
+		"retries": 5,
+		"retryTime": 5
+	},
+	"types": {},
+	"browseServerOptions": null,
+	"service": "supsi",
+	"subservice": "/",
+	"providerUrl": "http://opcua-agent-supsi:4001",
+	"pollingExpiration": "200000",
+	"pollingDaemonFrequency": "20000",
+	"deviceRegistrationDuration": "P1M",
+	"defaultType": null,
+	"contexts": [],
+	"contextSubscriptions": []
+}

--- a/deployment/plat-infra-services/opcua-agent-supsi/config.properties
+++ b/deployment/plat-infra-services/opcua-agent-supsi/config.properties
@@ -1,0 +1,89 @@
+## SOUTHBOUND CONFIGURATION (OPC UA)
+namespace-ignore=2,7
+endpoint=opc.tcp://somewhere.at.supsi:5001/UA/BotServer
+
+## NORTHBOUND CONFIGURATION (ORION CONTEXT BROKER)
+context-broker-host=orion
+context-broker-port=1026
+fiware-service=supsi
+fiware-service-path=/
+
+
+## AGENT CONFIGURATION
+server-base-root=/
+server-port=4001
+provider-url=http://opcua-agent-supsi:4001
+
+device-registration-duration=P1M
+device-registry-type=memory
+
+log-level=DEBUG
+
+namespaceIndex=3
+namespaceNumericIdentifier=1000
+
+# MONGO-DB CONFIGURATION (required if device-registry-type=mongodb)
+mongodb-host=nowhere
+mongodb-port=27017
+mongodb-db=opcua_agent_supsi
+mongodb-retries=5
+mongodb-retry-time=5
+
+## DATATYPE MAPPING OPCUA --> NGSI
+OPC-datatype-Number=Number
+OPC-datatype-Decimal128=Number
+OPC-datatype-Double=Number
+OPC-datatype-Float=Number
+OPC-datatype-Integer=Integer
+OPC-datatype-UInteger=Integer
+OPC-datatype-String=Text
+OPC-datatype-ByteString=Text
+#END DATATYPE MAPPING OPCUA --> NGSI
+
+## SESSION PARAMETERS
+requestedPublishingInterval=10
+requestedLifetimeCount=1000
+requestedMaxKeepAliveCount=10
+maxNotificationsPerPublish=100
+publishingEnabled=true
+priority=10
+
+#SubscriptionsStrategy
+uniqueSubscription=false
+
+## MONITORING PARAMETERS
+samplingInterval=1
+queueSize=10000
+discardOldest=false
+
+## SERVER CERT E AUTH
+securityMode=None
+securityPolicy=None
+userName=
+password=
+
+#securityMode=SIGNANDENCRYPT
+#securityPolicy=1Basic256
+#password=password1
+#userName=user1
+
+#api-ip=192.168.13.153
+
+## ADMINISTRATION SERVICES
+api-port=8080
+
+## POLL COMMANDS SETTINGS
+polling=false
+polling-commands-timer=1000
+pollingDaemonFrequency=20000
+pollingExpiration=200000
+
+## AGENT ID
+agent-id=age01_
+entity-id=age01_Car # used only during tests
+
+## CONFIGURATION
+configuration=#api
+
+## CHECK TIMER POLLING DEVICES
+checkTimer=2000

--- a/deployment/plat-infra-services/opcua-agent-supsi/kustomization.yaml
+++ b/deployment/plat-infra-services/opcua-agent-supsi/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml
+
+configMapGenerator:
+- name: opcua-agent-supsi-config
+  files:
+  - config.json
+  - config.properties


### PR DESCRIPTION
This PR implements a fully fledged OPC UA agent service to be used by SUPSI. Specifically, the following got implemented.

* Manifests to run the OPC UA agent in a K8s cluster.
* In-memory configuration. The service pre-loads device mappings and other config in memory to speed up OPC UA to FIWARE data translation.
* Persistence. No Mongo DB backend. Data sits in memory (it isn't much actually) but it's loaded from K8s configmaps, so that's the persistence backend. (If the pod restarts, config map data gets loaded again in memory; all service pods share the same config map data.) 
* IaC management. The manifests of all agent-related resources are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Simplified config model. All the agent config sits in our repo, including devices and mappings. Argo CD automatically deploys this data to the configmaps the service uses as a persistence backend---see point above. No need to fiddle with awkward service calls to figure out what devices have been defined, what their mappings are, or to add new devices. It's all defined in `config.json` and `config.properties` in our repo. Look at those files to figure out the lay of the land at a glance. Edit them to add or modify device defs, mappings etc. Argo CD takes care of propagating your changes to the cluster.

### Notes

1. Single OPC UA Server to Agent mode. That's the only op mode we can support. There's no way to connect an OPC UA agent to more than one OPC UA server. So we'll have to run an agent for each and every OPC UA server we want to connect to the platform. See #81 for the implications.
2. SUPSI configuration. SUPSI will have to define their specific device and mappings and configure the OPC UA server URL.
3. Service replicas. Currently set to 0. Reason: the agent won't work w/o an OPC UA server URL, but at the moment we don't have a server to connect to.