### PR TITLE
Complete CrateDB deployment

### DIFF
--- a/deployment/mesh-infra/storage/crate.yaml
+++ b/deployment/mesh-infra/storage/crate.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: crate-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: microk8s-hostpath
+  resources:
+    requests:
+      storage: 10Gi

--- a/deployment/mesh-infra/storage/kustomization.yaml
+++ b/deployment/mesh-infra/storage/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- crate.yaml
 - keycloak.yaml

--- a/deployment/plat-infra-services/cratedb/base.yaml
+++ b/deployment/plat-infra-services/cratedb/base.yaml
@@ -19,9 +19,9 @@ spec:
     name: postgres
   selector:
     app: crate
-  type: NodePort
 
 ---
+
 kind: StatefulSet
 apiVersion: "apps/v1"
 metadata:

--- a/deployment/plat-infra-services/cratedb/base.yaml
+++ b/deployment/plat-infra-services/cratedb/base.yaml
@@ -71,6 +71,10 @@ spec:
           - -Cgateway.recover_after_nodes=1
           - -Cgateway.expected_nodes=${EXPECTED_NODES}
           - -Cpath.data=/data
+        volumeMounts:
+          # Mount persistent storage on configured data dir (path.data).
+          - mountPath: /data
+            name: crate-volume
         resources:
           limits:
             # How much memory each pod gets.
@@ -104,3 +108,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      volumes:
+      - name: crate-volume
+        persistentVolumeClaim:
+          claimName: crate-pvc


### PR DESCRIPTION
We deployed Crate during the Nov 2021 demo sprint. But some bits and pieces were still missing and some improvements were needed. This PR completes the work we started in Nov 2021.

* Physical storage. Crate writes its DB files to `/data` so we mount this dir on a K8s volume backed by 10GB physical storage. That should be enough disk space for the next few months but we'll probably have to up it as soon as we connect real-world devices. (Consider we've only got 120GB physical storage at the moment and other DBs to cater for, so it's best not to allocate too much storage until we expand our underlying physical capacity.)
* Security. You can't access Crate directly from outside the cluster anymore. So e.g. you won't be able to browse to `kitt4sme.collab-cloud.eu:4200` and get into the admin console. That'd have been a huge security liability going forward since we'll start collecting data from the shop floor in a couple of months.