### PR TITLE
Bounce Argo CD Server on secret config change

### DIFF
--- a/deployment/mesh-infra/argocd/argocd-server.yaml
+++ b/deployment/mesh-infra/argocd/argocd-server.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+  annotations:
+    # Tell Reloader to bounce the Argo CD server whenever the SSO config
+    # and built-in admin credentials change.
+    secret.reloader.stakater.com/reload: "argocd-secret"

--- a/deployment/mesh-infra/argocd/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/kustomization.yaml
@@ -13,3 +13,4 @@ patchesStrategicMerge:
 - argocd-cmd-params-cm.yaml
 - argocd-rbac-cm.yaml
 - argocd-secret.yaml
+- argocd-server.yaml


### PR DESCRIPTION
This PR fixes #111.

The reason for not being able to log in to Argo CD with Keycloak was that the OIDC client secret had changed in Keycloak. Even though the  `argocd-secret` was updated with the new OIDC client secret value, Argo CD Server didn't pick it up so it was still using the old OIDC client secret value. So Keycloak would deny access.

We now use Reloader to bounce Argo CD Server whenever `argocd-secret` changes.