### PR TITLE
GA demo preps

### DIFF
--- a/deployment/mesh-infra/security/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/ingress-policy.yaml
@@ -25,5 +25,6 @@ spec:
         - "/auth/*"
         - "/argocd"
         - "/argocd/*"
+        - "/orion/*"
         - "/orion/version"
         - "/quantumleap/version"

--- a/deployment/plat-infra-services/quantumleap/base.yaml
+++ b/deployment/plat-infra-services/quantumleap/base.yaml
@@ -64,7 +64,7 @@ spec:
           - name: db-init
             mountPath: /db-init
       containers:
-        - image: "orchestracities/quantumleap:0.8.2"
+        - image: "orchestracities/quantumleap:0.8.3"
           imagePullPolicy: IfNotPresent
           name: quantumleap
           ports:


### PR DESCRIPTION
This PR changes some settings to make sure we can demo our apps at the GA without trouble:

- let external clients call Orion without a security token
- upgrade to Quantum Leap 0.8.3---the previous version won't work w/ the newly developed [dashboards][dazzler]


[dazzler]: https://github.com/c0c0n3/kitt4sme.dazzler