### PR TITLE
Basic Dazzler deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/dazzler/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/dazzler/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: dazzler
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/dazzler
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/dazzler/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/dazzler/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
 - project.yaml
+- dazzler
 - roughnator

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -69,6 +69,14 @@ spec:
         host: argocd-server.argocd.svc.cluster.local
         port:
           number: 80
+  - match:  # NOTE (3)
+    - uri:
+        prefix: /dazzler
+    route:
+    - destination:
+        host: dazzler.default.svc.cluster.local
+        port:
+          number: 8000
 
 # NOTE
 # 1. URL rewriting. We use overlapping prefixes to make sure `/x`, `/x/`
@@ -85,4 +93,8 @@ spec:
 #
 # 2. Keycloak base path. Keycloak is configured with a `web-context`
 # of `auth`, which makes every URL in the UI is relative to `/auth`.
+# So we don't need a rewrite rule in this case.
+#
+# 3. Dazzler base path. Dazzler is configured with a root URL of
+# `dazzler`, which makes every URL in the UI is relative to `/dazzler`.
 # So we don't need a rewrite rule in this case.

--- a/deployment/mesh-infra/security/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/ingress-policy.yaml
@@ -25,6 +25,7 @@ spec:
         - "/auth/*"
         - "/argocd"
         - "/argocd/*"
+        - "/dazzler/*"
         - "/orion/*"
         - "/orion/version"
         - "/quantumleap/version"

--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dazzler
+  name: dazzler
+spec:
+  ports:
+  - name: http
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: dazzler
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dazzler
+  name: dazzler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dazzler
+  template:
+    metadata:
+      labels:
+        app: dazzler
+    spec:
+      containers:
+        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:latest"
+          imagePullPolicy: IfNotPresent
+          name: dazzler
+          ports:
+          - containerPort: 8000
+            name: http
+          env:
+          - name: "quantumleap_base_url"
+            value: "http://quantumleap:8668"

--- a/deployment/plat-app-services/dazzler/kustomization.yaml
+++ b/deployment/plat-app-services/dazzler/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- dazzler
-- roughnator
+- base.yaml


### PR DESCRIPTION
This PR implements a basic [Dazzler][dazzler] deployment. Features:

* General purpose, multi-tenant, Dash-powered dashboards.
* VIQE inspection dashboard.
* Roughnator surface roughness estimate dashboard.
* IaC. Dazzler manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.

#### Note
* Security. Even though this PR doesn't implement security, it can easily be bolted on top since dashboard routes include the tenant name. So we can easily apply an OPA policy similar to the one we've implemented for the FIWARE services. Once that's in place, we can restrict access to the Dazzler service to requests containing a valid Keycloak token.


[dazzler]: https://github.com/c0c0n3/kitt4sme.dazzler