### PR TITLE
Upgrade Sealed Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 KITT4SME live platform
 ----------------------
-> The AI's coming the shop floor!
+> The AI's coming to the shop floor!
 
 This repo contains a work-in-progress reference implementation of the
 [KITT4SME platform][k4s].

--- a/deployment/mesh-infra/security/kustomization.yaml
+++ b/deployment/mesh-infra/security/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
 - ingress-policy.yaml
 - opa.yaml
-- https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.3/controller.yaml
+- https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/controller.yaml
 - reloader.yaml
 - secrets
 

--- a/nix/kubeseal.nix
+++ b/nix/kubeseal.nix
@@ -20,7 +20,7 @@
 
 buildGoModule rec {
   pname = "kubeseal";
-  version = "0.17.3";
+  version = "0.17.5";
 
   src = fetchFromGitHub {
     owner = "bitnami-labs";

--- a/nix/kubeseal.nix
+++ b/nix/kubeseal.nix
@@ -1,24 +1,18 @@
 #
 # Custom Sealed Secrets package.
-# Actually it's a fat C&P from Nixpkgs:
+#
+# Couldn't find any easy way to extend/override Nixpkgs 20.11's own
+# kubeseal expression to make it build kubeseal 0.17.5
 #
 # - https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/cluster/kubeseal/default.nix
 #
-# The only thing I changed is the `version` attribute below.
-# Uh? Wot?! Why not just use an expression like
+# So I've rolled out a bare build recipe whipped together by looking
+# at what the kubeseal Makefile target does. To be replaced with the
+# official Nixpkgs expression when it gets updated to build 0.17.5.
 #
-#   kubeseal = pkgs.kubeseal.overrideAttrs ( old: rec {
-#     version = "0.17.3";
-#     ...
-#   });
-#
-# Cuz it don't flippin work? If you try that, you actually get whatever
-# version is in your Nixpkgs---`0.16.0` in my case. See my rant about
-# overriding Go packages in `opa.nix`.
-#
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, stdenv, go_1_17, fetchFromGitHub }:
 
-buildGoModule rec {
+stdenv.mkDerivation rec {
   pname = "kubeseal";
   version = "0.17.5";
 
@@ -26,21 +20,31 @@ buildGoModule rec {
     owner = "bitnami-labs";
     repo = "sealed-secrets";
     rev = "v${version}";
-    sha256 = "sha256-7u7lsMeeZOUGn8eb8sjV9Td+XNEUPDvbSaITdp1JTf4=";
+    sha256 = "sha256-cqOSMAagefKQiKKtgVbk1UFKYGBXQleJ1pgcJ/VyOnM=";
   };
 
-  vendorSha256 = null;
+  GO_LD_FLAGS = "-s -w -X main.VERSION=${version}";
 
-  doCheck = false;
+  buildInputs = [ go_1_17 ];
 
-  subPackages = [ "cmd/kubeseal" ];
+  buildPhase = ''
+    mkdir -p $out/mod-cache
+    export GOMODCACHE=$out/mod-cache
 
-  ldflags = [ "-s" "-w" "-X main.VERSION=${version}" ];
+    mkdir -p $out/build-cache
+    export GOCACHE=$out/build-cache
+
+    go build -o kubeseal -ldflags "$GO_LD_FLAGS" ./cmd/kubeseal
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp kubeseal $out/bin
+  '';
 
   meta = with lib; {
     description = "A Kubernetes controller and tool for one-way encrypted Secrets";
     homepage = "https://github.com/bitnami-labs/sealed-secrets";
     license = licenses.asl20;
-    maintainers = with maintainers; [ groodt ];
+    maintainers = with maintainers; [ c0c0n3 ];
   };
 }


### PR DESCRIPTION
This PR upgrades our Sealed Secret setup from version `0.17.3` to `0.17.5`. This is a hot-fix for the open call devs since version `0.17.3` is unstable and shouldn't be used anymore.

See:

- #144 
- #147
