### PR TITLE
Worker Profiler deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - project.yaml
 - dazzler
 - roughnator
+- workerpro

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/workerpro/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/workerpro/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: workerpro
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/workerpro
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/workerpro/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/workerpro/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/plat-app-services/kustomization.yaml
+++ b/deployment/plat-app-services/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - dazzler
 - roughnator
+- workerpro

--- a/deployment/plat-app-services/workerpro/base.yaml
+++ b/deployment/plat-app-services/workerpro/base.yaml
@@ -5,10 +5,12 @@ metadata:
     app: workerpro
   name: workerpro
 spec:
+  type: NodePort
   ports:
   - name: http
-    port: 7777
     protocol: TCP
+    port: 7777
+    nodePort: 7777
     targetPort: 80
   selector:
     app: workerpro

--- a/deployment/plat-app-services/workerpro/base.yaml
+++ b/deployment/plat-app-services/workerpro/base.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: workerpro
+  name: workerpro
+spec:
+  ports:
+  - name: http
+    port: 7777
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: workerpro
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: workerpro
+  name: workerpro
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workerpro
+  template:
+    metadata:
+      labels:
+        app: workerpro
+    spec:
+      containers:
+        - image: "codenception/worker-profiler:2.7"
+          imagePullPolicy: IfNotPresent
+          name: workerpro
+          ports:
+          - containerPort: 80
+            name: http
+          env:
+          - name: "POSTGRES_CONNECTION_STRING"
+            value: "Host=postgres:5432;Username=postgres;Password=TODO;Database=WorkerProfiler"

--- a/deployment/plat-app-services/workerpro/base.yaml
+++ b/deployment/plat-app-services/workerpro/base.yaml
@@ -41,5 +41,10 @@ spec:
           - containerPort: 80
             name: http
           env:
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgres-users
+                key: postgres.password
           - name: "POSTGRES_CONNECTION_STRING"
-            value: "Host=postgres:5432;Username=postgres;Password=TODO;Database=WorkerProfiler"
+            value: "Host=postgres:5432;Username=postgres;Password=$(POSTGRES_PASSWORD);Database=WorkerProfiler"

--- a/deployment/plat-app-services/workerpro/kustomization.yaml
+++ b/deployment/plat-app-services/workerpro/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml

--- a/dev/workerpro/docker-compose.yml
+++ b/dev/workerpro/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+
+  worker-profiler:
+    image: codenception/worker-profiler:2.7
+    # get around race conditions---e.g. WorkerPro tries to create its
+    # DB before Timescale is able to accept connections. Luckily, blindly
+    # restarting WorkerPro is safe...or is it?
+    restart: always
+    depends_on:
+      - timescale
+    ports:
+      - 7777:80
+    networks:
+      - e2etest
+    environment:
+      - POSTGRES_CONNECTION_STRING=Host=timescale:5432;Username=postgres;Password=*;Database=WorkerProfiler
+#      - POSTGRES_CONNECTION_STRING=postgres://postgres:*@timescale:5432/WorkerProfiler
+
+  timescale:
+    image: timescale/timescaledb-postgis:1.7.5-pg12
+    ports:
+      - "5432:5432"
+    networks:
+      - e2etest
+    environment:
+      - POSTGRES_PASSWORD=*
+
+networks:
+  e2etest:
+    driver: bridge


### PR DESCRIPTION
This PR implements a basic Worker Profiler deployment.

* K8s manifests to run the Worker Profiler service in the Kitt4sme cloud.
* IaC. Worker Profiler manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Routing. The service is exposed to clients outside the cluster through a K8s node port (`7777`). This isn't optimal, but see #151 about it.
* Storage. The service connects to the existing Postgres instance in the platform infra service layer.
* Security. The password to connect to the DB is encrypted in a sealed secret rather than being plain text in the K8s manifest. For the rest, there's no security at the moment, anyone with the right URL can access the service. We'll secure the service later, see #153.
* Test env. There's a Docker Compose file in `dev/workerpro` you can use for testing the service locally. It comes with a backend DB setup close to what we have in the cloud.