### PR TITLE
Basic SADS cloud deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - dazzler
 - profilers
 - roughnator
+- sads

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/sads/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/sads/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: sads
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/sads
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/sads/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/sads/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -77,6 +77,14 @@ spec:
         host: dazzler.default.svc.cluster.local
         port:
           number: 8000
+  - match:  # NOTE (4)
+    - uri:
+        prefix: /sads
+    route:
+    - destination:
+        host: sads.default.svc.cluster.local
+        port:
+          number: 8501
 
 # NOTE
 # 1. URL rewriting. We use overlapping prefixes to make sure `/x`, `/x/`
@@ -96,5 +104,10 @@ spec:
 # So we don't need a rewrite rule in this case.
 #
 # 3. Dazzler base path. Dazzler is configured with a root URL of
-# `dazzler`, which makes every URL in the UI is relative to `/dazzler`.
+# `dazzler`, which makes every URL in the UI relative to `/dazzler`.
 # So we don't need a rewrite rule in this case.
+#
+# 4. SADS base path. The Streamlit server is configured with a root
+# URL of `sads`, which makes every URL in the UI relative to `/sads`.
+# So we don't need a rewrite rule in this case.
+#

--- a/deployment/mesh-infra/security/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/ingress-policy.yaml
@@ -29,3 +29,4 @@ spec:
         - "/orion/*"
         - "/orion/version"
         - "/quantumleap/version"
+        - "/sads/*"

--- a/deployment/plat-app-services/sads/base.yaml
+++ b/deployment/plat-app-services/sads/base.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sads
+  name: sads
+spec:
+  ports:
+  - name: http
+    port: 8501
+    protocol: TCP
+    targetPort: 8501
+  selector:
+    app: sads
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: sads
+  name: sads
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sads
+  template:
+    metadata:
+      labels:
+        app: sads
+    spec:
+      containers:
+        - image: "ghcr.io/c0c0n3/kitt4sme.flaw-sleuth:0.2.0"
+          imagePullPolicy: IfNotPresent
+          name: sads
+          ports:
+          - containerPort: 8501
+            name: http
+          env:
+          - name: "STREAMLIT_SERVER_BASE_URL_PATH"
+            value: "/sads"

--- a/deployment/plat-app-services/sads/kustomization.yaml
+++ b/deployment/plat-app-services/sads/kustomization.yaml
@@ -2,7 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- dazzler
-- profilers
-- roughnator
-- sads
+- base.yaml

--- a/dev/sads/docker-compose.yml
+++ b/dev/sads/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+services:
+
+  mongodb:
+    image: mongo:4.4
+    networks:
+      - simtests
+
+  orion:
+    image: fiware/orion-ld:0.8.0
+    entrypoint: orionld -fg -multiservice -ngsiv1Autocast -dbhost mongodb -logLevel DEBUG
+    networks:
+      - simtests
+    ports:
+      - "1026:1026"
+    depends_on:
+      - mongodb
+
+  crate:
+    image: crate:4.5.1
+    command: crate -Cauth.host_based.enabled=false
+      -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
+    ports:
+      - "4200:4200"
+      - "4300:4300"
+    networks:
+     - simtests
+
+  quantumleap:
+    image: orchestracities/quantumleap:0.8.2
+    depends_on:
+      - crate
+    networks:
+      - simtests
+    ports:
+      - "8668:8668"
+    environment:
+      - CRATE_HOST=crate
+      - USE_GEOCODING=False
+      - CACHE_QUERIES=False
+      - LOGLEVEL=DEBUG
+
+  flawsleuth:
+    image: ghcr.io/c0c0n3/kitt4sme.flaw-sleuth:latest
+    networks:
+      - simtests
+    ports:
+      - "8501:8501"
+
+networks:
+  simtests:
+    driver: bridge


### PR DESCRIPTION
This PR implements a basic SADS deployment.

* K8s manifests to run the SADS service in the Kitt4sme cloud.
* IaC. SADS manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Routing. The service is exposed to clients outside the cluster through Istio path-based routing. Endpoint: `<cloud-url>/sads/`, e.g. http://kitt4sme.collab-cloud.eu/sads/.
* Security. There's no security at the moment, anyone with the right URL can access the service. We'll secure the service later, see #160.
* Test env. There's a Docker Compose file in `dev/sads` you can use for testing the service locally. It comes with a setup close to what we have in the cloud. Also keep in mind, using the [Flaw Sleuth][flaw-sleuth] simulator is usually easier.

[flaw-sleuth]: https://github.com/c0c0n3/kitt4sme.flaw-sleuth