### PR TITLE
Basic VIQE deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - profilers
 - roughnator
 - sads
+- viqe

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/viqe/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/viqe/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: viqe
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/viqe
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/viqe/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/viqe/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -85,6 +85,16 @@ spec:
         host: sads.default.svc.cluster.local
         port:
           number: 8501
+  - match:
+    - uri:
+        prefix: /viqe/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: viqe.default.svc.cluster.local
+        port:
+          number: 8000
 
 # NOTE
 # 1. URL rewriting. We use overlapping prefixes to make sure `/x`, `/x/`

--- a/deployment/mesh-infra/security/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/ingress-policy.yaml
@@ -30,3 +30,4 @@ spec:
         - "/orion/version"
         - "/quantumleap/version"
         - "/sads/*"
+        - "/viqe/*"

--- a/deployment/plat-app-services/viqe/base.yaml
+++ b/deployment/plat-app-services/viqe/base.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: viqe
+  name: viqe
+spec:
+  ports:
+  - name: http
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: viqe
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: viqe
+  name: viqe
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: viqe
+  template:
+    metadata:
+      labels:
+        app: viqe
+    spec:
+      containers:
+        - image: "ghcr.io/c0c0n3/kitt4sme.viqe:0.1.0"
+          imagePullPolicy: IfNotPresent
+          name: viqe
+          ports:
+          - containerPort: 8000
+            name: http
+          env:
+          - name: "QUANTUMLEAP_BASE_URL"
+            value: "http://quantumleap:8668"

--- a/deployment/plat-app-services/viqe/kustomization.yaml
+++ b/deployment/plat-app-services/viqe/kustomization.yaml
@@ -2,9 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- dazzler
-- insight
-- profilers
-- roughnator
-- sads
-- viqe
+- base.yaml


### PR DESCRIPTION
This PR implements a basic VIQE cloud service deployment.

* K8s manifests to run the VIQE service in the Kitt4sme cloud.
* IaC. SADS manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Routing. The service is exposed to clients outside the cluster through Istio path-based routing. Endpoint: `<cloud-url>/viqe/`, e.g. http://kitt4sme.collab-cloud.eu/viqe/.
* Security. There's no security at the moment, anyone with the right URL can access the service. We'll secure the service later, see #163.
* Test env. Using the various environment in the [service repo][viqe].


[viqe]: https://github.com/c0c0n3/kitt4sme.viqe