### PR TITLE
Refresh Dazzler deployment

### DIFF
--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -32,7 +32,7 @@ spec:
         app: dazzler
     spec:
       containers:
-        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:latest"
+        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.3.0"
           imagePullPolicy: IfNotPresent
           name: dazzler
           ports:

--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -39,5 +39,14 @@ spec:
           - containerPort: 8000
             name: http
           env:
-          - name: "quantumleap_base_url"
-            value: "http://quantumleap:8668"
+          - name: "DAZZLER_CONFIG"
+            value: "/etc/dazzler-config.yaml"
+          volumeMounts:
+          - name: dazzler-config
+            mountPath: /etc/dazzler-config.yaml
+            subPath: dazzler-config.yaml
+            readOnly: true
+      volumes:
+      - name: dazzler-config
+        configMap:
+          name: dazzler-config

--- a/deployment/plat-app-services/dazzler/dazzler-config.yaml
+++ b/deployment/plat-app-services/dazzler/dazzler-config.yaml
@@ -1,0 +1,10 @@
+quantumleap_base_url: http://quantumleap:8668
+boards:
+  csic:
+  - builder: dazzler.dash.board.roughnator.dash_builder
+    board_path: roughnator
+  itek:
+  - builder: dazzler.dash.board.viqe.raw_material_dash_builder
+    board_path: raw_materials
+  - builder: dazzler.dash.board.viqe.tweezers_dash_builder
+    board_path: tweezers

--- a/deployment/plat-app-services/dazzler/kustomization.yaml
+++ b/deployment/plat-app-services/dazzler/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - base.yaml
+
+configMapGenerator:
+- name: dazzler-config
+  files:
+  - dazzler-config.yaml


### PR DESCRIPTION
This PR upgrades Dazzler to version `0.3.0` which includes the new VIQE dashboards. Istio routing and security haven't changed. The dashboards that got wired in for this deployment are:

- Roughnator. Same as before. Available at `<cloud base url>/dazzler/csic/-/roughnator`.
- VIQE raw materials. New VIQE dashboard for raw materials inspection to be used in the Hand Tools field trial. Available at `<cloud base url>/dazzler/itek/-/raw_materials`.
- VIQE tweezers. New VIQE dashboard for tweezers inspection to be used in the Hand Tools field trial. Available at `<cloud base url>/dazzler/itek/-/tweezers`

