### PR TITLE
Fix broken kubeseal package

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -36,10 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-22-05": {
+      "locked": {
+        "lastModified": 1664883812,
+        "narHash": "sha256-wqBAcVRBxls2nVaNeQaOy9SRg/bvEUiD26TQDprIg8U=",
+        "owner": "NixOs",
+        "repo": "nixpkgs",
+        "rev": "fe76645aaf2fac3baaa2813fd0089930689c53b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOs",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixie": "nixie",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-22-05": "nixpkgs-22-05"
       }
     }
   },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -3,19 +3,22 @@
 
   inputs = {
     nixpkgs.url = "github:NixOs/nixpkgs/nixos-21.11";
+    nixpkgs-22-05.url = "github:NixOs/nixpkgs/nixos-22.05";
     nixie = {
       url = "github:c0c0n3/nixie";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, nixie }:
+  outputs = { self, nixpkgs, nixpkgs-22-05, nixie }:
     let
       buildWith = nixie.lib.flakes.mkOutputSetForCoreSystems nixpkgs;
       mkSysOutput = { system, sysPkgs }:
       let
         opa = sysPkgs.callPackage ./opa.nix {};
-        kubeseal = sysPkgs.callPackage ./kubeseal.nix {};
+        # kubeseal = sysPkgs.callPackage ./kubeseal.nix {};  # NOTE (1)
+        kubeseal = nixpkgs-22-05.legacyPackages.${system}.kubeseal;
+        # ^ Nixpkgs 22.05 comes w/ kubeseal 0.17.5, same as kubeseal.nix
       in {
         defaultPackage.${system} = with sysPkgs; buildEnv {
           name = "kitt4sme-cluster-shell";
@@ -25,3 +28,10 @@
     in
       buildWith mkSysOutput;
 }
+# NOTE
+# 1. kubeseal. Ideally we'd build it off Nixpkgs 21.11, our main package
+# source at the moment. In fact, that'd save quite a bit of build time
+# and almost 4GB space in the Nix store---on MacOS. That's why we whipped
+# together that kubeseal.nix recipe. But it looks like we did it too quickly,
+# as it breaks on some Linux flavours, see
+# - https://github.com/c0c0n3/kitt4sme.live/issues/167


### PR DESCRIPTION
This PR fixes #167 by fetching kubeseal `0.17.5` from Nixpkgs `22.05`.

Ideally we'd build kubeseal off Nixpkgs `21.11`, our main package source at the moment. In fact, that'd save quite a bit of build time and almost 4GB space in the Nix store---on MacOS. That's why we whipped together our own `kubeseal.nix` recipe. But it looks like we did it too quickly, as it breaks on some Linux flavours---see #167, #166, #144.

A better option would be to upgrade the whole mesh infra since it's about two years old. That means we could also easily switch to the latest Nixpkgs where all the tools we need are there and actually work. But for the time being we put in place this stopgap solution to help all the peeps out there who got stuck on this issue.