### PR TITLE
Basic Fatigue Monitoring System deployment

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/fams/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/fams/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: fams
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/fams
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/fams/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/fams/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - project.yaml
 - dazzler
+- fams
 - insight
 - profilers
 - roughnator

--- a/deployment/mesh-infra/security/secrets/fams-image.sh
+++ b/deployment/mesh-infra/security/secrets/fams-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#
+# Generate a SealedSecret for pulling the Fatigue Monitoring System
+# image.
+# Usage:
+#
+#   $ ./fams-image.sh TokenYouGotFromSUPSI
+#
+# where the argument is a GitLab token SUPSI gave you that includes
+# a permission to pull images from https://gitlab-core.supsi.ch:5050.
+#
+# Notice `kubeseal` needs to be able to access the cluster for this
+# script to work. You can also work offline if you like, but you'll
+# have to fetch the controller pub key with `kubeseal --fetch-cert`
+# beforehand. Read the Sealed Secrets docs for the details.
+#
+
+set -e
+
+GITLAB_USR="gitlab+deploy-k4s-fams"
+GITLAB_TOKEN=$1
+
+kubectl create secret docker-registry fams-image \
+        --docker-server="https://gitlab-core.supsi.ch:5050" \
+        --docker-username="${GITLAB_USR}" \
+        --docker-password="${GITLAB_TOKEN}" \
+        -o yaml --dry-run='client' | \
+    sed 's!^  creationT.*$!  namespace: default\n  annotations:\n    sealedsecrets.bitnami.com/managed: "true"!' | \
+    kubeseal -o yaml -w fams-image.yaml

--- a/deployment/mesh-infra/security/secrets/fams-image.yaml
+++ b/deployment/mesh-infra/security/secrets/fams-image.yaml
@@ -1,0 +1,19 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: fams-image
+  namespace: default
+spec:
+  encryptedData:
+    .dockerconfigjson: AgAN2vgLd/sZnWBpFsGI2olRlk6gpkINCYSiiz2svxMyGY74L9GKYWVnQu+nPpdgPtMY3pIlpMnyVFzqKc1HpbkyFgrk2vhFLc+kD+ynok8dLb2Ux49QifYLXTQHrzZk4ii6KIpDwuPESHNovrInLgP9xEqFAa3s3Yy0tei4a2PfFXL3I3Kdp/UAfElgS/Vp4rz0WM11aWLZiODvrEyxVMuwrL7QkvbrD2UPNEfdHh6vLq02NpPyjm9ufV23CKDeZLOm3Zrq/pvBfS2Uza/V2ZYeXjaUVOy8vjRYA0cX0wWuLbFV5Ww0muNNc/5deFXioOZf8ewGACka9FmhHegg+pXcqBeVg1gOV2Oh3NvM5p84Qz7D2M39AQ1RtzUn3r+zZZV/Q2UeW80fKy9cxkSfNJk8KNoHUsxmfn+7kgSQJuFOpJyf7m40iCObaMgtP9mJBajYu5Z1sBJ5PXDWh27YW1sCoVPi68d1oDSXiNuPYcpimANzGbOyV3d8t7AC7sS3GyfQrg1RToEIV5XFTvIPRKlyfrvbCQLInJ2/Q8jQOo7HeM8GlbeKHS8m6WD/DjJPweJBb/kiNtMa9+Vp/VylLdndLT/IgPP/A2JGIc65IeM7zz+mDEXQPLZoHtuFKyxPj5c5I70ChafOYBmHj5lyL3aIOat7x2aEE37PO1LK5lSXVeTC46+hsSFQ/f8SEj88+1YUoAc3WSlTg3X/n38zaSGe2sYKBl36McYNVb2vh+Nx/kHFuYF2qicnVjf/RwudRQohV0GYl243rYZOEo2QoxKu+HFuH7Eg19bvgO3+MfDT+jDR8LXcRx6Lm9T0uKf7x3mLs8xYLZ08DuCI8V0hNVZLXwG7PtnVHLTy4faCu6KriOqLTE8qfZHqTbhJPHmOCFz92pLGjeQcbZj/
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      creationTimestamp: null
+      name: fams-image
+      namespace: default
+    type: kubernetes.io/dockerconfigjson
+

--- a/deployment/mesh-infra/security/secrets/kustomization.yaml
+++ b/deployment/mesh-infra/security/secrets/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
 - argocd.yaml
+- fams-image.yaml
 - insight-image.yaml
 - keycloak-builtin-admin.yaml
 - postgres-users.yaml

--- a/deployment/plat-app-services/fams/base.yaml
+++ b/deployment/plat-app-services/fams/base.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fams
+  name: fams
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fams
+  template:
+    metadata:
+      labels:
+        app: fams
+    spec:
+      imagePullSecrets:
+        - name: fams-image
+      containers:
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/human-digital-twin/fams:0.1.0-k4s"
+          imagePullPolicy: IfNotPresent
+          name: fams
+          args:
+          - +app=fiware
+          - +static_data_manager=orion
+          - +dynamic_data_manager=orion
+          - +connected_workers_manager=orion
+          env:
+          - name: "RUNNING_MODE"
+            value: "2"
+          - name: "CONF_PATH"
+            value: "/data/"
+          - name: "TZ"
+            value: "CET"
+          - name: "SERVER_ADDRESS"
+            value: "orion"
+          - name: "TENANT"
+            value: "supsi"

--- a/deployment/plat-app-services/fams/base.yaml
+++ b/deployment/plat-app-services/fams/base.yaml
@@ -8,7 +8,7 @@ metadata:
     # Tell Reloader to bounce the service whenever the secret changes.
     secret.reloader.stakater.com/reload: "fams-image"
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: fams

--- a/deployment/plat-app-services/fams/base.yaml
+++ b/deployment/plat-app-services/fams/base.yaml
@@ -4,6 +4,9 @@ metadata:
   labels:
     app: fams
   name: fams
+  annotations:
+    # Tell Reloader to bounce the service whenever the secret changes.
+    secret.reloader.stakater.com/reload: "fams-image"
 spec:
   replicas: 1
   selector:

--- a/deployment/plat-app-services/fams/kustomization.yaml
+++ b/deployment/plat-app-services/fams/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml

--- a/deployment/plat-app-services/kustomization.yaml
+++ b/deployment/plat-app-services/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - dazzler
+- fams
 - insight
 - profilers
 - roughnator


### PR DESCRIPTION
This PR implements a basic Fatigue Monitoring System (FAMS) deployment.

* K8s manifests to run the FAMS service in the Kitt4sme cloud.
* IaC. FAMS manifests are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Security. The FAMS image is private and K8s pulls it through a Docker secret. We manage the secret the usual way with Sealed Secrets and Reloader. So the actual Docker secret is never stored in this repo, what gets stored here is the Sealed Secret encrypting the data that makes up the Docker secret. We whipped together a script to generate the Sealed Secret from a GitLab Access Token containing a permission to pull the image.
* Docs. How to use sealed secrets/reloader for docker image secrets. (Security Ops page.)


### Notes

1. Service replicas. Currently set to 0. Reason: the GitLab token we have in the Sealed Secret is invalid, so K8s won't be able to pull the image. (We don't want to run FAMS in the Kitt4sme live instance just yet because we'd like to wait for FAMS to get a patent before using its image in the cloud.)
2. Authorised service use. If you fork this repo and would like to use FAMS, you'll first have to get in touch with @vcutrona  (SUPSI) to agree on terms of use. Then he'll issue you with a token you can use to pull the image. Use the `fams-image.sh` script in `deployment/mesh-infra/security/secrets` to generate a Sealed Secret for that token. Then set the service replicas to at least 1. Finally commit your changes and the service should automatically go live soon after.
