### PR TITLE
Mongo DB storage

### DIFF
--- a/deployment/mesh-infra/storage/kustomization.yaml
+++ b/deployment/mesh-infra/storage/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
 - crate.yaml
 - keycloak.yaml
+- mongo.yaml
 - postgres.yaml

--- a/deployment/mesh-infra/storage/mongo.yaml
+++ b/deployment/mesh-infra/storage/mongo.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: microk8s-hostpath
+  resources:
+    requests:
+      storage: 10Gi

--- a/deployment/plat-infra-services/mongodb/base.yaml
+++ b/deployment/plat-infra-services/mongodb/base.yaml
@@ -41,3 +41,11 @@ spec:
         ports:
         - containerPort: 27017
           name: mongo
+        volumeMounts:
+          # Mount persistent storage on default data dir.
+          - mountPath: "/data/db"
+            name: mongo-volume
+      volumes:
+      - name: mongo-volume
+        persistentVolumeClaim:
+          claimName: mongo-pvc


### PR DESCRIPTION
This PR implements a basic Mongo DB persistent storage as requested by #5.

Features:

* Physical storage. We make Mongo DB write its DB files to /data/db and mount this dir on a K8s volume backed by 10GB physical storage. That should be enough disk space for the next few months but we'll probably have to up it as soon as we connect real-world devices. (Consider we've only got 120GB physical storage at the moment and other DBs to cater for, so it's best not to allocate too much storage until we expand our underlying physical capacity.)