### PR TITLE
JSON Agent

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/json-agent/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/json-agent/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: json-agent
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-infra-services/json-agent
+- op: replace
+  path: /spec/project
+  value: plat-infra-services

--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/json-agent/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/json-agent/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml

--- a/deployment/mesh-infra/argocd/projects/plat-infra-services/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-infra-services/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - project.yaml
 - cratedb
 - grafana
+- json-agent
 - mongodb
 - mqtt
 - opcua-agent-supsi

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -115,6 +115,16 @@ spec:
         host: ulagent.default.svc.cluster.local
         port:
           number: 7896
+  - match:
+    - uri:
+        prefix: /jsonagent/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: jsonagent.default.svc.cluster.local
+        port:
+          number: 7896
 
 # NOTE
 # 1. URL rewriting. We use overlapping prefixes to make sure `/x`, `/x/`

--- a/deployment/plat-infra-services/json-agent/base.yaml
+++ b/deployment/plat-infra-services/json-agent/base.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: jsonagent
+  name: jsonagent
+spec:
+  ports:
+  - name: iota-north
+    port: 4041
+    protocol: TCP
+    targetPort: 4041
+  - name: iota-south
+    port: 7896
+    protocol: TCP
+    targetPort: 7896
+  selector:
+    app: jsonagent
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jsonagent
+  name: jsonagent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jsonagent
+  template:
+    metadata:
+      labels:
+        app: jsonagent
+    spec:
+      containers:
+      - image: "fiware/iotagent-json:1.25.0"
+        imagePullPolicy: IfNotPresent
+        name: jsonagent
+        ports:
+        - containerPort: 4041
+          name: iota-north
+        - containerPort: 7896
+          name: iota-south
+        volumeMounts:
+          - name: config
+            mountPath: /opt/iotagent-json/config.js
+            subPath: config.js
+      volumes:
+      - name: config
+        configMap:
+          name: json-agent-config

--- a/deployment/plat-infra-services/json-agent/config.js
+++ b/deployment/plat-infra-services/json-agent/config.js
@@ -1,0 +1,105 @@
+/*
+ * JSON Agent JavaScript config file.
+ * See:
+ * - https://github.com/telefonicaid/iotagent-json/blob/master/config.js
+ */
+let config = {};
+
+
+/* Use our Mosquitto service to receive device data and send commands
+ * to devices.
+ *
+ * Notice we tell the agent to never prefix topics with a leading '/'
+ * since that's bad practice. See:
+ * - https://github.com/telefonicaid/iotagent-node-lib/issues/866
+ * - https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/
+ */
+config.mqtt = {
+    host: 'mosquitto',
+    port: 1883,
+    protocol: 'mqtt',
+    qos: 0,
+    retain: false,
+    retries: 5,
+    retryTime: 5,
+    keepalive: 60,
+    avoidLeadingSlash: true,
+    disabled: false
+};
+
+/* Don't attempt to connect to AMQP.
+ * Setting `config.amqp.disabled` to `false` has no effect. The agent
+ * will try connecting to `127.0.0.1:5672` every 5 secs. Probably a
+ * bug. As a workaround, setting the whole `amqp` object to `null`
+ * stops the agent from connecting. Not documented anywhere, but it
+ * works.
+ */
+config.amqp = null;
+
+/* HTTP endpoint to receive device data.
+ * Quite confusingly, you've got to specify the path in the `iota`
+ * section---see `iota.defaultResource` below. Anyway, the endpoint
+ * for us is `jsonagent:7896/iot/json`.
+ */
+config.http = {
+    port: 7896
+};
+
+config.iota = {
+    /* Device provisioning and management endpoint.
+     * Listen on port 4041 and default the FIWARE service on device
+     * registration to "kitt4sme".
+     */
+    server: {
+        port: 4041
+    },
+    logLevel: 'DEBUG',
+    service: 'kitt4sme',
+    subservice: '/',
+
+    /* Context Broker interaction.
+     * Forward device data, after JSON-to-NGSI-v2 translation, to our
+     * Context Broker service at `orion:1026`. Use `kitt4sme` as a
+     * default FIWARE service if the device registry doesn't hold
+     * one for the device at hand.
+     * Use the JSON Agent service name and port when registering as
+     * a Context Provider with Context Broker.
+     */
+    contextBroker: {
+        host: 'orion',
+        port: '1026',
+        ngsiVersion: 'v2',
+        fallbackTenant: 'kitt4sme',
+        fallbackPath: '/'
+    },
+    providerUrl: 'http://jsonagent:4041',
+
+    /* In-memory device registry.
+     * Since we configure device data to NGSI translation here and
+     * have any changes propagated through our GitOps pipeline, we
+     * don't have to stash away device registration and mapping in
+     * Mongo DB. Also make sure device registration never expires,
+     * since it's all in this config file.
+     */
+    deviceRegistry: {
+        type: 'memory'
+    },
+    mongodb: {},
+    deviceRegistrationDuration: 'P100Y',
+
+    /* Device data to NGSI translation.
+     * Put your mapping in the `types` map, our GitOps pipeline will
+     * take care of updating the agent service with the new mapping.
+     * See:
+     * - https://iotagent-node-lib.readthedocs.io/en/latest/api.html#service-group-api
+     * - https://iotagent-node-lib.readthedocs.io/en/latest/api.html#type-configuration
+     */
+    defaultResource: '/iot/json',
+    defaultType: 'Thing',
+    timestamp: true,
+    explicitAttrs: false,
+    autocast: true,
+    types: {}
+};
+
+module.exports = config;

--- a/deployment/plat-infra-services/json-agent/kustomization.yaml
+++ b/deployment/plat-infra-services/json-agent/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml
+
+configMapGenerator:
+- name: json-agent-config
+  files:
+  - config.js

--- a/deployment/plat-infra-services/kustomization.yaml
+++ b/deployment/plat-infra-services/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - cratedb/
 - grafana/
+- json-agent/
 - mongodb/
 - opcua-agent-supsi/
 - orion/


### PR DESCRIPTION
This PR implements a fully-fledged JSON Agent deployment with HTTP and MQTT transports as #185 requested. Specifically, the following got implemented.

* Manifests to run JSON Agent in a K8s cluster. The agent comes with an internal endpoint for provisioning and two external endpoints to get JSON device data in, one over HTTP, the other over MQTT---see #181 for our current MQTT setup.
* Routing. We expose the HTTP endpoint at `<kitt4sme-base-url>/jsonagent/` so devices can POST JSON data at `<kitt4sme-base-url>/jsonagent/iot/json?k=<api-key>&i=<device-id>`. To send JSON data over MQTT, devices use the MQTT WebSocket implemented in #181 and the topic: `json/<api-key>/<device-id>/attrs`.
* Security. Istio handles TLS termination for the HTTP endpoint and delegates security decisions to the existing FIWARE OPA policy. Security over MQTT works as explained in #181.
* In-memory configuration. The service pre-loads device mappings and other config in memory to speed up JSON to FIWARE data translation---see `config.js`.
* Persistence. No Mongo DB backend. Data sits in memory (it isn't much actually) but it's loaded from K8s configmaps, so that's the persistence backend. (If the pod restarts, config map data gets loaded again in memory; all service pods share the same config map data.)
* IaC management. The manifests of all agent-related resources are tied to an Argo CD app in the mesh infra project so we can easily manage deployments through a GUI too.
* Simplified config model. All the agent config sits in our repo, including devices and mappings. Argo CD automatically deploys this data to the configmaps the service uses as a persistence backend---see point above. No need to fiddle with awkward service calls to figure out what devices have been defined, what their mappings are, or to add new devices. It's all defined in `config.js`  in our repo. Look at that file to figure out the lay of the land at a glance. Edit it to add or modify device defs, mappings etc. Argo CD takes care of propagating your changes to the cluster.
