### PR TITLE
Digital Datasheets deployment continuation 

### DIFF
--- a/deployment/mesh-infra/security/ingress-policy.yaml
+++ b/deployment/mesh-infra/security/ingress-policy.yaml
@@ -31,3 +31,6 @@ spec:
         - "/quantumleap/version"
         - "/sads/*"
         - "/viqe/*"
+        - "/datasheets/*"
+        - "/datasheets-backend-rest/*"
+


### PR DESCRIPTION
http://kitt4sme.collab-cloud.eu/datasheets/
http://kitt4sme.collab-cloud.eu/datasheets-backend-rest/

Hi, I think this should be included to expose both of the endpoints above. 