### PR TITLE
Enabled TLS, not tested, need to still create secrets on cluster

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -12,7 +12,17 @@ spec:
       name: http
       number: 80
       protocol: HTTP
-
+    tls:
+      httpsRedirect: false
+  - hosts:
+    - "*"
+    port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: istio-gw-cert
 ---
 
 apiVersion: networking.istio.io/v1beta1


### PR DESCRIPTION
reouting ingress.yaml file has been updated to include TLS and nonsecure rerouting is set to false so insecure URL's should still work. New routing has to be deployed and kubernetes secret creates as per: [Secure external HTTP traffic#77](https://github.com/c0c0n3/kitt4sme.live/issues/77)

Server certificates are at /etc/certs (server.key and server.crt) 