### PR TITLE
Use https for ArgoCD SSO

### DIFF
--- a/deployment/mesh-infra/argocd/argocd-cm.yaml
+++ b/deployment/mesh-infra/argocd/argocd-cm.yaml
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-  url: http://kitt4sme.collab-cloud.eu/argocd
+  url: https://kitt4sme.collab-cloud.eu/argocd
   oidc.config: |
     name: Keycloak
-    issuer: http://kitt4sme.collab-cloud.eu/auth/realms/master
+    issuer: https://kitt4sme.collab-cloud.eu/auth/realms/master
     clientID: argocd
     clientSecret: $oidc.keycloak.clientSecret
     requestedScopes: ["openid", "profile", "email", "groups"]


### PR DESCRIPTION
This PR updates the ArgoCD configuration to use HTTPs when performing the OIDC code grant flow.
This is because as of #207, we have proper TLS certificates and we can use HTTPs.