### PR TITLE
Rollback #209

### DIFF
--- a/deployment/mesh-infra/argocd/argocd-cm.yaml
+++ b/deployment/mesh-infra/argocd/argocd-cm.yaml
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
 data:
-  url: https://kitt4sme.collab-cloud.eu/argocd
+  url: http://kitt4sme.collab-cloud.eu/argocd
   oidc.config: |
     name: Keycloak
-    issuer: https://kitt4sme.collab-cloud.eu/auth/realms/master
+    issuer: http://kitt4sme.collab-cloud.eu/auth/realms/master
     clientID: argocd
     clientSecret: $oidc.keycloak.clientSecret
     requestedScopes: ["openid", "profile", "email", "groups"]


### PR DESCRIPTION
This PR undoes #209. Even though we now have proper SSL certs, our version of Argo CD can't validate them---see #210 about it. So for now we implement a stopgap solution which will let us access ArgoCD over HTTP---yea, massive security liability right there, but hey, we still don't have any real data in the collab cloud instance.

In detail

- The Argo CD config map (`argocd-cm`) specifies plain HTTP URLs for both the ArgoCD and Keycloak endpoints.
- The Argo CD OIDC client in the Keycloak master realm specifies plain HTTP URLs for all the ArgoCD endpoints.
- The Keycloak master realm login settings have `Require SSL: none`

As soon as #210 is implemented we can ditch this stopgap solution by restoring HTTPs across the board (`argocd-cm`, OIDC client) and setting `Require SSL: all requests`