### PR TITLE
Port mapping issue

### DIFF
--- a/deployment/plat-app-services/profilers/base.yaml
+++ b/deployment/plat-app-services/profilers/base.yaml
@@ -8,7 +8,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: 8080
+    port: 80
     targetPort: 80
   selector:
     app: profilers


### PR DESCRIPTION
This change should resolve the issue, the site should be accessible from "kitt4sme.collab-cloud.eu:8080/"