### PR TITLE
updated argocd to 2.4.0 version to fix SSL issue

### DIFF
--- a/deployment/mesh-infra/argocd/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 
 resources:
 - namespace.yaml
-- https://raw.githubusercontent.com/argoproj/argo-cd/v2.2.5/manifests/install.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.0/manifests/install.yaml
 - projects
 
 patchesStrategicMerge:


### PR DESCRIPTION
Updated ArgoCD to 2.4.0 and tested with local deployment of the cluster. Seemed to work just fine, but later synced agains main branch and revert back to 2.2.5. I didn't fork the repo so I think that behavior is expected and the change is OK.