### PR TITLE
Adaptive Questionnaire path-based routing

### DIFF
--- a/deployment/plat-app-services/aq/base.yaml
+++ b/deployment/plat-app-services/aq/base.yaml
@@ -35,16 +35,6 @@ spec:
     metadata:
       labels:
         app: aq
-      annotations:
-        # This annotation tells Istio **not** to add a sidecar.
-        # For now AQ can't work with a sidecar b/c of
-        # - https://github.com/c0c0n3/kitt4sme.live/issues/216
-        # Zap this annotation when there's a fix for the above
-        # issue or when AQ implements
-        # - https://github.com/IDSIA/adapquest/issues/25
-        # since then we can do URL-based routing instead of using
-        # a node port.
-        sidecar.istio.io/inject: "false"
     spec:
       initContainers:
         - image: "timescale/timescaledb-postgis:2.3.0-pg13"

--- a/deployment/plat-app-services/aq/base.yaml
+++ b/deployment/plat-app-services/aq/base.yaml
@@ -5,14 +5,9 @@ metadata:
     app: aq
   name: aq
 spec:
-  # zap node port as soon as we have a fix for
-  # - https://github.com/IDSIA/adapquest/issues/25
-  # and change service port from 8443 to 8080.
-  type: NodePort
   ports:
   - name: http
-    nodePort: 8443
-    port: 8443
+    port: 8080
     protocol: TCP
     targetPort: 8080
   selector:
@@ -70,10 +65,8 @@ spec:
           - containerPort: 8080
             name: http
           env:
-          # uncomment this when IDSIA release a fix for the servlet root
-          # context, see: https://github.com/IDSIA/adapquest/issues/25
-          # - name: "server_servlet_context-path"
-          #   value: "/aq"
+          - name: "server_servlet_context-path"
+            value: "/aq"
           - name: MAGIC_API_KEY
             value: "QWRhcHRpdmUgU3VydmV5"
           - name: DB_DBMS

--- a/deployment/plat-app-services/aq/base.yaml
+++ b/deployment/plat-app-services/aq/base.yaml
@@ -63,7 +63,7 @@ spec:
             mountPath: /db-init
             readOnly: true
       containers:
-        - image: "ghcr.io/idsia/adapquest:v1.6.1"
+        - image: "ghcr.io/idsia/adapquest:v1.6.3"
           imagePullPolicy: IfNotPresent
           name: aq
           ports:


### PR DESCRIPTION
This PR improves the basic Adaptive Questionnaire deployment of #217.

- AQ got upgraded to version `1.6.3` which includes some bug fixes, most notably https://github.com/IDSIA/adapquest/issues/25. This fix enables us to use URL path based routing.
- Routing. We ditched the node port setup of #217 and are now using the usual path-based approach, implementing a URL-path route `/aq` to deliver external HTTP requests to the AQ service.
- Istio sidecar. This PR puts back the Istio sidecar that #217 removed. In fact, #216 isn't an issue anymore with URL-path routes.