### PR TITLE
Revert "updated argocd to 2.4.0 version to fix SSL issue"

### DIFF
--- a/deployment/mesh-infra/argocd/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 
 resources:
 - namespace.yaml
-- https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.0/manifests/install.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.2.5/manifests/install.yaml
 - projects
 
 patchesStrategicMerge:


### PR DESCRIPTION
Reverts c0c0n3/kitt4sme.live#215 didn't seem to work as planned after all... well back to the drawing board.