### PR TITLE
AQ customisation

### DIFF
--- a/deployment/plat-app-services/aq/base.yaml
+++ b/deployment/plat-app-services/aq/base.yaml
@@ -94,6 +94,12 @@ spec:
             value: "true"
           - name: ADAPQUEST_CONTROLLER_EXPERIMENTS
             value: "false"
+          - name: ADAPQUEST_PAGE_TITLE
+            value: "KITT4SME Adaptive Questionnaire"
+          - name: ADAPQUEST_EXIT_URL
+            value: "https://ramp.eu"
+          - name: ADAPQUEST_EXIT_TEXT
+            value: "find a kit for your needs"
           volumeMounts:
           - name: aq-surveys
             mountPath: /adaptive/data/surveys

--- a/deployment/plat-app-services/aq/base.yaml
+++ b/deployment/plat-app-services/aq/base.yaml
@@ -58,7 +58,7 @@ spec:
             mountPath: /db-init
             readOnly: true
       containers:
-        - image: "ghcr.io/idsia/adapquest:v1.6.3"
+        - image: "ghcr.io/idsia/adapquest:v1.6.4"
           imagePullPolicy: IfNotPresent
           name: aq
           ports:


### PR DESCRIPTION
This PR upgrades Adaptive Questionnaire to version `1.6.4` and customises it with

- A title of "KITT4SME Adaptive Questionnaire"
- A button to find a suitable kit in the RAMP marketplace. At the end of the survey, Adaptive Questionnaire displays a "find a kit for your needs" button. When the user click on the button the browser gets redirected to https://ramp.eu/?sid=xxx, where `xxx` is the survey's session ID. This allows RAMP to pass on the session ID to Platform Configurator which can then get hold of the survey data in the Postgres DB.

Notice the RAMP URL will most likely have to be reconfigured (`ADAPQUEST_EXIT_URL` env var) after this PR since at this stage we still don't know what the RAMP endpoint is that will process KITT4SME AQ surveys.