### PR TITLE
Platform configurator deployment

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -171,6 +171,16 @@ spec:
         host: aq.default.svc.cluster.local
         port:
           number: 8080
+  - match:
+    - uri:
+        prefix: /platform-configurator/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: platform-configurator.default.svc.cluster.local
+        port:
+          number: 8000
 
 # NOTE
 # 1. URL rewriting. We use overlapping prefixes to make sure `/x`, `/x/`

--- a/deployment/mesh-infra/security/secrets/kustomization.yaml
+++ b/deployment/mesh-infra/security/secrets/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
 - insight-image.yaml
 - keycloak-builtin-admin.yaml
 - mosquitto-passwd.yaml
+- platform-configurator-image.yaml
 - postgres-users.yaml

--- a/deployment/mesh-infra/security/secrets/platform-configurator-image.sh
+++ b/deployment/mesh-infra/security/secrets/platform-configurator-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#
+# Generate a SealedSecret for pulling the Platform Configurator
+# image.
+# Usage:
+#
+#   $ ./platform-configurator.sh TokenYouGotFromSUPSI
+#
+# where the argument is a GitLab token SUPSI gave you that includes
+# a permission to pull images from https://gitlab-core.supsi.ch:5050.
+#
+# Notice `kubeseal` needs to be able to access the cluster for this
+# script to work. You can also work offline if you like, but you'll
+# have to fetch the controller pub key with `kubeseal --fetch-cert`
+# beforehand. Read the Sealed Secrets docs for the details.
+#
+
+set -e
+
+GITLAB_USR="gitlab+deploy-pc-k4s-cloud"
+GITLAB_TOKEN=$1
+
+kubectl create secret docker-registry platform-configurator-image \
+        --docker-server="https://gitlab-core.supsi.ch:5050" \
+        --docker-username="${GITLAB_USR}" \
+        --docker-password="${GITLAB_TOKEN}" \
+        -o yaml --dry-run='client' | \
+    sed 's!^  creationT.*$!  namespace: default\n  annotations:\n    sealedsecrets.bitnami.com/managed: "true"!' | \
+    kubeseal -o yaml -w platform-configurator-image.yaml

--- a/deployment/mesh-infra/security/secrets/platform-configurator-image.yaml
+++ b/deployment/mesh-infra/security/secrets/platform-configurator-image.yaml
@@ -1,0 +1,19 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: platform-configurator-image
+  namespace: default
+spec:
+  encryptedData:
+    .dockerconfigjson: AgA29Tz80MOFzf9dYIRiKDT8KVLX71/Wo/2+lYJWjPBVpQ6avwQRjVKmADFKiqXKuO5TKBiDYYsowXVqjjlSnwhjztlnEZWcsTs7zniVl6Dr1Jjs1TTLGnzxIKDDWaeGEFvyTJdrOeBI6uWr/d85rewOD3eGGdK8yaiFZHiBjk5qoNv+y+EVz3R2p8vrLQsG3GhMDJBfQ+GIE+2o2owok/IN9EBzMSva1El3RHT4zhJxhOaCDeMsopoTwZUkPjJWXieX6WzUDY0RAm3trBOo5yltL5yL8NoQ+52C7If9UQ55HN8J3u1VBivjEYwnW5g1GOSFULnJiMa/gAMRMOA88EUqXRYQNJ4plmDADSOabLu+0mw8jo/I6pnhgOEMmu27fw52z3/umkpuvq9PIjQr+3ZvmZXDSRkNGidTeT4X0kP+teMwhoTIjqjF4RZTKpcfMPZT4i+nH4B1ZtLNZrUQThVvbbh5AUWxmtUsIBB12ML9dZLhUprkTt8SiQM/1Tgumt9X7BfvalNJWF897wxGW09TV4PnQ6jhNWBpktLAul+S4gzP1tJ2HAjwJhWZxRTcrD/jh2RLzg2b1QxWDRsWjCB7W1kkS8ao+BQx0wGntObM/QSGDBqzsoHUzdbm5PqEnjRt09J4HbBb34JG2UmDZPY+6eIKMNXjTrrlzL6B9ORUZftafKn+8VmO+HhEobP1WeO47oaVLTfCT7imJ2+QnbxMqJKgL0xNQ5O3bUC0npQq0hp9g6Ywxt3cy80WIhS97R3aYHiwBNqT64R5yXL0gjQHIAKjZ3t9WScQ7JYXPzGRUAbGw0gvMMZcXl/annetlciA30VTKxux+CZj2SRwHekPE8+xrOmredmN2kbAcjs+nfYmFcPI8Z+fJnhbfD1sYygHnc1SadZKVJbTqrj1qU3EJangHLk3kQKQZpK5mrobY8hJyiCnrY3oGVzl/0b9sE7kOAr+RO+Vhf3ISQ==
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      creationTimestamp: null
+      name: platform-configurator-image
+      namespace: default
+    type: kubernetes.io/dockerconfigjson
+

--- a/deployment/plat-app-services/kustomization.yaml
+++ b/deployment/plat-app-services/kustomization.yaml
@@ -7,9 +7,9 @@ resources:
 - dazzler
 - fams
 - insight
+- platform-configurator
 - profilers
 - roughnator
 - sads
 - sads-offline
 - viqe
-

--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: platform-configurator
+  name: platform-configurator
+  annotations:
+    # Tell Reloader to bounce the service whenever the secret changes.
+    secret.reloader.stakater.com/reload: "platform-configurator-image"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platform-configurator
+  template:
+    metadata:
+      labels:
+        app: platform-configurator
+    spec:
+      imagePullSecrets:
+        - name: platform-configurator-image
+      containers:
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:dev"
+          imagePullPolicy: IfNotPresent
+          name: platform-configurator
+          env:
+          - name: "DS_DB_HOST"
+            value: "postgres"
+          - name: "DS_DB_PORT"
+            value: "5432"
+          - name: "DS_DB_NAME"
+            value: "db_KITT"
+          - name: "DS_DB_USER"
+            value: "postgres"
+          - name: "DS_DB_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: postgres-users
+                key: postgres.password
+          - name: "AQ_DB_HOST"
+            value: "postgres"
+          - name: "AQ_DB_PORT"
+            value: "5432"
+          - name: "AQ_DB_NAME"
+            value: "adaptive"
+          - name: "AQ_DB_USER"
+            value: "ada"
+          - name: "AQ_DB_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: postgres-users
+                key: aq.password

--- a/deployment/plat-app-services/platform-configurator/kustomization.yaml
+++ b/deployment/plat-app-services/platform-configurator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base.yaml


### PR DESCRIPTION
This pull request deploys the Platform Configurator to the KITT4SME Platform.
The Docker image is available in SUPSI's GItlab Registry, which is private. This requires to re-generate the sealed secret with a new token provided by SUPSI.