### PR TITLE
Platform Configurator deployment refresh

### DIFF
--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -67,3 +67,5 @@ spec:
               secretKeyRef:
                 name: postgres-users
                 key: aq.password
+          - name: "RAMP_KITS_URL"
+            value: "https://ramp.eu/kits"

--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -37,7 +37,7 @@ spec:
       imagePullSecrets:
         - name: platform-configurator-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:dev"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.1.0"
           imagePullPolicy: IfNotPresent
           name: platform-configurator
           env:


### PR DESCRIPTION
This PR refreshes the Platform Configurator image to the latest version (`0.1.0`) and adds a "RAMP_KITS_URL" to configure the RAMP endpoint to call to pass on a kit configuration.