### PR TITLE
FAMS dashboard

### DIFF
--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -32,7 +32,7 @@ spec:
         app: dazzler
     spec:
       containers:
-        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.4.0"
+        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.5.0"
           imagePullPolicy: IfNotPresent
           name: dazzler
           ports:

--- a/deployment/plat-app-services/dazzler/dazzler-config.yaml
+++ b/deployment/plat-app-services/dazzler/dazzler-config.yaml
@@ -11,3 +11,6 @@ boards:
     board_path: raw_materials
   - builder: dazzler.dash.board.viqe.tweezers_dash_builder
     board_path: tweezers
+  demo:
+  - builder: dazzler.dash.board.fams.dash_builder
+    board_path: fams


### PR DESCRIPTION
This PR upgrades Dazzler to version `0.5.0` and enables the FAMS dashboard for the "demo" tenant.