### PR TITLE
Update PC (v0.3.0)

### DIFF
--- a/deployment/mesh-infra/security/secrets/api-keys.yaml
+++ b/deployment/mesh-infra/security/secrets/api-keys.yaml
@@ -1,0 +1,19 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: api-keys
+  namespace: default
+spec:
+  encryptedData:
+    pc.ramp.kits.svc: AgAONu4BS7Moa+QwRqoCTPG9ID7guDrPnqcTZ+EJP7eJCjGqRYNJXlPD7POY0vZCIwqZsyFpEaaX4m7iGOOzV8htr7q1UL/WFeSS+9w71oNUpiwlmnAqV1KgmQX54QcGq2TydIGETL8syVv3gLt+Z3fdbcbjh/5I247FCE/BkgcdmaBUJnPuWmZrjJH4DrQjkQTyM4qZ63kkJHib0b2QhM2IaiQUP+ks0H4IVQA2vTQl2VjK+CYdqOWhQNd94eV4I6G1RBsCpjTRw0DwdxXLOU1HyUlJSrrFW8pr+4D2jHd8OWWlBkFX2dW8H9WOAKV2+6LlYIinKBAN2HjHQXtJN9aqUUGWyLwtjM5jz4AKoJUcWOU8PdvPfuhSqbT8WnCoH3b96LbCmryPWQgK1xBeX7673AKjbTy2pTr1KUOT/ClFWpF7sreA+2UxR3YjbQzu7ceY3PvGpJ4kMsAGSLCWfzQjoRk8J5hGhsicPJZeEledsXyNg+fZcrlCpxdITMFyWc6Cpit9Zb9s/6yRMZzJ0jssjPrceTXISbhSbKSyYQmhoExbCFNOSmetynJ7ERFjT/gbz3OPq725I61hVf7LaADRDwNAtkhYsCHYu4WxrHYdXQ0AEcEUJ9my9fPm976FXFFAJ0S4EyuTj6u/LnHqYtLMWfLu/fcN2wdxfOXqC6XlU/AatfTSM+on9jAwj2Wi39fJ9ClGP6+ey/DHbSYKjpQ2J5NqRcZDIKk=
+  template:
+    data: null
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      creationTimestamp: null
+      name: api-keys
+      namespace: default
+    type: Opaque
+

--- a/deployment/mesh-infra/security/secrets/kustomization.yaml
+++ b/deployment/mesh-infra/security/secrets/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 
 resources:
+- api-keys.yaml
 - argocd.yaml
 - fams-image.yaml
 - insight-image.yaml

--- a/deployment/mesh-infra/security/secrets/templates/api-keys.yaml
+++ b/deployment/mesh-infra/security/secrets/templates/api-keys.yaml
@@ -1,0 +1,31 @@
+#
+# Plain K8s Secret template to generate the actual SealedSecret to be
+# instantiated in the cluster. To generate the SealedSecret, first edit
+# the password field below, then run
+#
+#   $ kubeseal -o yaml < templates/api-keys.yaml > api-keys.yaml
+#
+# Notice `kubeseal` needs to be able to access the cluster for that to
+# work. You can also work offline if you like, but you'll have to fetch
+# the controller pub key with `kubeseal --fetch-cert` beforehand. Read
+# the docs for the details.
+#
+# WARNING. **Never** commit this file to the repo with an actual
+# password in it. After editing this file, just ask git to ditch
+# the local changes.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-keys
+  namespace: default
+  annotations:
+    # Let Sealed Secrets Controller update this Secret whenever the
+    # corresponding SealedSecret changes. When we update a SealedSecret,
+    # Controller will extract its Secret, but if the old Secret currently
+    # live in K8s doesn't have this annotation, Controller will refuse to
+    # update it with the new content just unsealed.
+    sealedsecrets.bitnami.com/managed: "true"
+type: Opaque
+stringData:
+  pc.ramp.kits.svc: platform-configurator-api-key-to-access-ramp

--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -37,7 +37,7 @@ spec:
       imagePullSecrets:
         - name: platform-configurator-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.2.0"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.3.0"
           imagePullPolicy: IfNotPresent
           name: platform-configurator
           env:
@@ -67,5 +67,12 @@ spec:
               secretKeyRef:
                 name: postgres-users
                 key: aq.password
-          - name: "RAMP_KITS_URL"
+          - name: "RAMP_KITS_SVC_URL"
+            value: "https://ramp.eu/ms/company/api/v1/service-request/kits"
+          - name: "RAMP_KITS_SVC_API_KEY"
+            valueFrom:
+              secretKeyRef:
+                 name: api-keys
+                 key: pc.ramp.kits.svc
+          - name: RAMP_REDIRECT_URL
             value: "https://ramp.eu/kits"


### PR DESCRIPTION
This PR refreshes Platform Configurator (v0.3.0)
Compared with v0.2.0:
- Kits are posted directly to "RAMP kits service" (RAMP_KITS_SVC_URL)
- The endpoint /kits-ramp redirects to a new page, based on the RAMP_REDIRECT_URL env var. The redirect includes "sid" as a query parameter
- Missing fields in datasheets are properly handled
- Exceptions while contacting RAMP are caught, but still not handled

Before going live, it is needed to create a new secret (name: **api-keys**, key: **pc.ramp.kits.svc**)