### PR TITLE
Deploy latest dazzler (0.6.0)

### DIFF
--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -32,7 +32,7 @@ spec:
         app: dazzler
     spec:
       containers:
-        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.5.0"
+        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.6.0"
           imagePullPolicy: IfNotPresent
           name: dazzler
           ports:


### PR DESCRIPTION
This PR deploys the latest Dazzler version (`0.6.0`) which fixes some issues with the FAMS dashboard:
- https://github.com/c0c0n3/kitt4sme.dazzler/pull/10