### PR TITLE
Patch Platform Configurator

### DIFF
--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -37,7 +37,7 @@ spec:
       imagePullSecrets:
         - name: platform-configurator-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.3.0"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.3.1"
           imagePullPolicy: IfNotPresent
           name: platform-configurator
           env:


### PR DESCRIPTION
This PR patches the Platform Configurator, which now does not consider tool's dependencies with unknown UUIDs (i.e., dependencies pointing to UUID not available in the datasheets database)