### PR TITLE
Update fams version (0.2.3)

### DIFF
--- a/deployment/plat-app-services/fams/base.yaml
+++ b/deployment/plat-app-services/fams/base.yaml
@@ -20,7 +20,7 @@ spec:
       imagePullSecrets:
         - name: fams-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/human-digital-twin/fams:0.2.0-k4s"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/human-digital-twin/fams:0.2.3-k4s"
           imagePullPolicy: IfNotPresent
           name: fams
           args:


### PR DESCRIPTION
This version updates FaMS to the lastest version.
This version fixes some bugs related to the download of dynamic data (from QL) of active workers (i.e., workers with an active session, wearing a device).