### PR TITLE
refresh IM to v1.0.4-k4s

### DIFF
--- a/deployment/plat-app-services/im/base.yaml
+++ b/deployment/plat-app-services/im/base.yaml
@@ -38,7 +38,7 @@ spec:
         - name: supsi-k4s-images
         - name: supsi-im-images
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/human-digital-twin/intervention-manager/intervention-manager:1.0.2-k4s"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/human-digital-twin/intervention-manager/intervention-manager:1.0.4-k4s"
           imagePullPolicy: IfNotPresent
           name: intervention-manager
           env:


### PR DESCRIPTION
This PR refreshes IM with the latest version that properly handles the servlet context path (i.e., /intervention-manager), also while displaying forms in the Tasklist page.
This allows us to use a proper routing for accessing the server, instead of resorting to using node ports.