### PR TITLE
Found an issue when building the cluster locally

### DIFF
--- a/deployment/mesh-infra/argocd/projects/plat-app-services/static-page/app.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/static-page/app.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: static-page
+- op: replace
+  path: /spec/source/path
+  value: deployment/plat-app-services/static-page
+- op: replace
+  path: /spec/project
+  value: plat-app-services

--- a/deployment/mesh-infra/argocd/projects/plat-app-services/static-page/kustomization.yaml
+++ b/deployment/mesh-infra/argocd/projects/plat-app-services/static-page/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+patchesJson6902:
+- target:
+    kind: Application
+    name: app
+  path: app.yaml


### PR DESCRIPTION
I needed to create a multipass instance with a larger disk space so decided to start from scratch found an error when running this command:
`$ kustomize build \
    https://github.com/c0c0n3/kitt4sme.live/deployment/mesh-infra/argocd | \
    kubectl apply -f -`

And found that the static page was missing the code from argocd directory. 