### PR TITLE
Static page url

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -24,7 +24,6 @@ spec:
       mode: SIMPLE
       credentialName: istio-gw-cert
 ---
-
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
@@ -35,18 +34,76 @@ spec:
   hosts:
   - "*"
   http:
-  - match:  # NOTE (1)
+  - match:
     - uri:
-        prefix: /orion/
-    - uri:
-        prefix: /orion
+        exact: /
     rewrite:
       uri: /
     route:
     - destination:
-        host: orion.default.svc.cluster.local
+        host: static-page.default.svc.cluster.local
         port:
-          number: 1026
+          number: 80
+  - match:
+    - uri:
+        exact: /style.css
+    rewrite:
+      uri: /style.css
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
+  - match:
+    - uri:
+        exact: /kitt4sme_architecture.png
+    rewrite:
+      uri: /kitt4sme_architecture.png
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
+  - match:
+    - uri:
+        prefix: /partners/
+    rewrite:
+      uri: /partners/
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
+  - match:
+    - uri:
+        exact: /kitt4sme_logo.png
+    rewrite:
+      uri: /kitt4sme_logo.png
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
+  - match:
+    - uri:
+        exact: /eu_logo.png
+    rewrite:
+      uri: /eu_logo.png
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
+  - match:
+    - uri:
+        exact: /favicon.ico
+    rewrite:
+      uri: /favicon.ico
+    route:
+    - destination:
+        host: static-page.default.svc.cluster.local
+        port:
+          number: 80
   - match:  # NOTE (1)
     - uri:
         prefix: /quantumleap/

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -59,7 +59,18 @@ spec:
         host: static-page.default.svc.cluster.local
         port:
           number: 80
-
+  - match:  # NOTE (1)
+    - uri:
+        prefix: /orion/
+    - uri:
+        prefix: /orion
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: orion.default.svc.cluster.local
+        port:
+          number: 1026
   - match:  # NOTE (1)
     - uri:
         prefix: /quantumleap/

--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -46,26 +46,6 @@ spec:
           number: 80
   - match:
     - uri:
-        exact: /style.css
-    rewrite:
-      uri: /style.css
-    route:
-    - destination:
-        host: static-page.default.svc.cluster.local
-        port:
-          number: 80
-  - match:
-    - uri:
-        exact: /kitt4sme_architecture.png
-    rewrite:
-      uri: /kitt4sme_architecture.png
-    route:
-    - destination:
-        host: static-page.default.svc.cluster.local
-        port:
-          number: 80
-  - match:
-    - uri:
         prefix: /partners/
     rewrite:
       uri: /partners/
@@ -74,36 +54,12 @@ spec:
         host: static-page.default.svc.cluster.local
         port:
           number: 80
-  - match:
-    - uri:
-        exact: /kitt4sme_logo.png
-    rewrite:
-      uri: /kitt4sme_logo.png
-    route:
+  - route:
     - destination:
         host: static-page.default.svc.cluster.local
         port:
           number: 80
-  - match:
-    - uri:
-        exact: /eu_logo.png
-    rewrite:
-      uri: /eu_logo.png
-    route:
-    - destination:
-        host: static-page.default.svc.cluster.local
-        port:
-          number: 80
-  - match:
-    - uri:
-        exact: /favicon.ico
-    rewrite:
-      uri: /favicon.ico
-    route:
-    - destination:
-        host: static-page.default.svc.cluster.local
-        port:
-          number: 80
+
   - match:  # NOTE (1)
     - uri:
         prefix: /quantumleap/


### PR DESCRIPTION
Two commits one outlines all the endpoints that should be available then the second is a simplified version of this, please think about how this code could affect things in a bigger picture.

The static page is now accessible via  "/" and the "/static-page"

https://kitt4sme.collab-cloud.eu/
https://kitt4sme.collab-cloud.eu/static-page/

Once merged I will create a ticket to remove the https://kitt4sme.collab-cloud.eu/static-page/