### PR TITLE
Update platform configurator

### DIFF
--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -37,9 +37,10 @@ spec:
       imagePullSecrets:
         - name: platform-configurator-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.4.1"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.5.0"
           imagePullPolicy: IfNotPresent
           name: platform-configurator
+          args: ["--root-path", "/platform-configurator"]
           env:
           - name: "DS_DB_HOST"
             value: "postgres"


### PR DESCRIPTION
Update platform configurator to v0.5.0

The new version uses new DTOs to meet RAMP APIs.
Also, adding the arg "--root-path /platform-configurator" to the deployment should solve the issue discussed in #273 (the tool documentation will be available at /platform-configurator/docs).