### PR TITLE
Home/Static page routing update

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -192,8 +192,6 @@ spec:
 
   - match:
     - uri:
-        prefix: /home
-    - uri:
         prefix: /home/
     rewrite:
       uri: /


### PR DESCRIPTION
Lets just make it accessible via https://kitt4sme.collab-cloud.eu/home/