### PR TITLE
SADS switchover

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -89,20 +89,20 @@ spec:
           number: 8000
   - match:  # NOTE (4)
     - uri:
-        prefix: /sads-offline
+        prefix: /sads
     route:
     - destination:
         host: sads-offline.default.svc.cluster.local
         port:
           number: 8501
-  - match:  # NOTE (5)
-    - uri:
-        prefix: /sads
-    route:
-    - destination:
-        host: sads.default.svc.cluster.local
-        port:
-          number: 8500
+  # - match:  # NOTE (5)
+  #   - uri:
+  #       prefix: /sads
+  #   route:
+  #   - destination:
+  #       host: sads.default.svc.cluster.local
+  #       port:
+  #         number: 8500
   - match:
     - uri:
         prefix: /viqe/

--- a/deployment/plat-app-services/sads-offline/base.yaml
+++ b/deployment/plat-app-services/sads-offline/base.yaml
@@ -40,4 +40,4 @@ spec:
             name: http
           env:
           - name: "STREAMLIT_SERVER_BASE_URL_PATH"
-            value: "/sads-offline"
+            value: "/sads"

--- a/deployment/plat-app-services/sads/base.yaml
+++ b/deployment/plat-app-services/sads/base.yaml
@@ -22,7 +22,7 @@ metadata:
     app: sads
   name: sads
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: sads


### PR DESCRIPTION
This PR make the SADS "offline" service the only SADS service accessible to external users.
In detail:
- SADS "online" is now set to have no replicas. The deployment descriptors are still there, but there's no service running in the cluster. Ditto for the Argo CD app---we keep it around just in case.
- SADS "offline" now handles all incoming requests to the `/sads` path.
- The `/sads-offline` path is unavailable.

### Breaking change notice
- Wamtechnik will have to change the URL they use to access SADS "offline". After this PR gets merged, they'll have to use "https://kitt4sme.collab-cloud.eu/sads/" instead of the current URL of "https://kitt4sme.collab-cloud.eu/sads-offline/".
- The "static page" (home) needs to be updated as well to reflect the URL change.
