### PR TITLE
hotfix - update platform configurator config

### DIFF
--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -43,7 +43,7 @@ spec:
           args: ["--root-path", "/platform-configurator"]
           env:
           - name: "DS_API_HOST"
-            value: "datasheet-backend:5000"
+            value: "http://datasheet-backend:5000"
           - name: "AQ_DB_HOST"
             value: "postgres"
           - name: "AQ_DB_PORT"


### PR DESCRIPTION
hotfix - Change the platform configurator config to avoid the exception "urllib3.exceptions.LocationValueError: No host specified."