### PR TITLE
try to fix YAML problem in SADS routing

### DIFF
--- a/deployment/mesh-infra/routing/ingress.yaml
+++ b/deployment/mesh-infra/routing/ingress.yaml
@@ -195,7 +195,7 @@ spec:
         host: platform-configurator.default.svc.cluster.local
         port:
           number: 8000
-  - match: # NOTE (4)
+  - match:
     - authority:
       exact: "sads.kitt4sme.collab-cloud.eu"
     route:


### PR DESCRIPTION
For some reason SADS block -authority: didn't compute and match section was translated to just {}