### PR TITLE
update platform configurator (v0.8.0)

### DIFF
--- a/deployment/plat-app-services/platform-configurator/base.yaml
+++ b/deployment/plat-app-services/platform-configurator/base.yaml
@@ -37,7 +37,7 @@ spec:
       imagePullSecrets:
         - name: platform-configurator-image
       containers:
-        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.7.0"
+        - image: "gitlab-core.supsi.ch:5050/dti-isteps/spslab/human-robot-interaction/kitt4sme/platform-configurator:0.8.0"
           imagePullPolicy: IfNotPresent
           name: platform-configurator
           # args: ["--root-path", "/platform-configurator"]  # only for path-based routing


### PR DESCRIPTION
The new version patches an error occurring when datasheets don't have a specified version (field information.version empty), or specify dependencies without a proper module ID