### PR TITLE
Fix Datasheets

### DIFF
--- a/deployment/plat-app-services/datasheets/frontend.yaml
+++ b/deployment/plat-app-services/datasheets/frontend.yaml
@@ -37,7 +37,7 @@ spec:
         name: datasheet-frontend
         env:
         - name: PUBLIC_URL
-          value: "/datasheets/"
+          value: "/"  # "/datasheets/" change root path
         ports:
         - containerPort: 3000
           name: http


### PR DESCRIPTION
The datasheets tool fails to load showing many errors related to resources not found at /datasheets/...
This might be due to the new platform deployment based on subdomains. This PR update the root path for the datasheets frontend.