### PR TITLE
Optiplant dashboard

### DIFF
--- a/deployment/plat-app-services/dazzler/base.yaml
+++ b/deployment/plat-app-services/dazzler/base.yaml
@@ -32,7 +32,7 @@ spec:
         app: dazzler
     spec:
       containers:
-        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.8.0"
+        - image: "ghcr.io/c0c0n3/kitt4sme.dazzler:0.9.0"
           imagePullPolicy: IfNotPresent
           name: dazzler
           ports:

--- a/deployment/plat-app-services/dazzler/dazzler-config.yaml
+++ b/deployment/plat-app-services/dazzler/dazzler-config.yaml
@@ -15,7 +15,5 @@ boards:
   - builder: dazzler.dash.board.fams.dash_builder
     board_path: fams
   optiplant:
-  - builder: dazzler.dash.board.insight.dash_builder
-    board_path: optiplant-insight
-  - builder: dazzler.dash.board.roughnator.dash_builder
-    board_path: optiplant-roughnator
+  - builder: dazzler.dash.board.optiplant.dash_builder
+    board_path: status


### PR DESCRIPTION
This PR upgrades Dazzler to version `0.9.0` so we can use the new Optiplant dashboard---see https://github.com/c0c0n3/kitt4sme.dazzler/pull/13. The dashboard is available from either URL below

- https://dazzler.kitt4sme.collab-cloud.eu/dazzler/optiplant/-/status/
- https://kitt4sme.collab-cloud.eu/dazzler/optiplant/-/status/
